### PR TITLE
Add API models for JSI services.

### DIFF
--- a/partners/JSI/JSI EventRegistry OpenAPI 2.0 specification.yaml
+++ b/partners/JSI/JSI EventRegistry OpenAPI 2.0 specification.yaml
@@ -1,0 +1,47 @@
+swagger: '2.0'
+info:
+  description: >-
+    Relation extraction API developed by JSI.
+  version: 1.0.0
+  title: JSI EventRegistry
+  contact:
+    email: gregor.leban@ijs.si
+host: analytics.eventregistry.org
+basePath: /api/v1
+schemes:
+  - http
+paths:
+  /categorize:
+    post:
+      summary: Categorize text by taxonomy
+      description: 'Categorize text by a categorization taxonomy: 1. DMOZ taxonomy; 2. News taxonomy (Business, Politics, Technology, Arts and Entertainment, Sports, Health, Science, Environment).'
+      operationId: categorize
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Annotation parameters
+          required: true
+          schema:
+            $ref: '#/definitions/ERCategorizationInput'
+      responses:
+        '200':
+          description: successful operation
+definitions:
+  ERCategorizationInput:
+    type: object
+    properties:
+      text:
+        type: string
+      taxonomy:
+        type: string
+        enum: [
+          "mediaTopics",
+          "eventTypes"
+        ]
+externalDocs:
+  description: More EventRegistry Event Types details
+  url: 'http://eventregistry.org/documentation?tab=categorize'

--- a/partners/JSI/JSI GraphBasedAnalytics OpenAPI 2.0 specification.yaml
+++ b/partners/JSI/JSI GraphBasedAnalytics OpenAPI 2.0 specification.yaml
@@ -1,0 +1,83 @@
+swagger: '2.0'
+info:
+  description: >-
+    Relation extraction API developed by JSI.
+  version: 1.0.0
+  title: JSI-relex
+  contact:
+    email: miha.jenko@ijs.si
+host: relex.ijs.si
+basePath: /
+schemes:
+  - http
+paths:
+  /extractRelations:
+    post:
+      summary: Extract relations from a given text
+      description: 'Extract relations from a given text.'
+      operationId: extractRelations
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Text and expected relation info
+          required: true
+          schema:
+            type: object
+      responses:
+        '200':
+          description: successful operation
+  /getEntityLabelInfo:
+    get:
+      summary: Get data attributed to an entity label
+      description: Can return multiple Entity instances, because Entities can have the same entity label
+      operationId: getEntityLabelInfo
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Entity info
+          required: true
+          schema:
+            type: object
+      responses:
+        '200':
+          description: successful operation
+  /getEntityNews:
+    get:
+      summary: Search EventRegistry news by Entity URI
+      description: Search EventRegistry news by Entity URI
+      operationId: getEntityNews
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Entity info
+          required: true
+          schema:
+            type: object
+      responses:
+        '200':
+          description: successful operation
+  /getEntityRelations:
+    get:
+      summary: Get relation instances including this Entity URI
+      description: Get relation instances including this Entity URI
+      operationId: getEntityRelations
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Entity info
+          required: true
+          schema:
+            type: object
+      responses:
+        '200':
+          description: successful operation

--- a/partners/JSI/JSI Wikifier OpenAPI 2.0 specification.yaml
+++ b/partners/JSI/JSI Wikifier OpenAPI 2.0 specification.yaml
@@ -1,0 +1,69 @@
+swagger: '2.0'
+info:
+  description: >-
+    Wikifier API developed by JSI.
+  version: 1.0.0
+  title: JSI Wikifier
+  contact:
+    email: janez.brank@ijs.si
+host: www.wikifier.org
+basePath: /
+schemes:
+  - http
+paths:
+  /annotate-article:
+    post:
+      summary: Wikify and annotate a given text
+      description: 'Wikify and annotate a given text.'
+      operationId: annotate-article
+      consumes:
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Annotation parameters
+          required: true
+          schema:
+            $ref: '#/definitions/WikifierInput'
+      responses:
+        '200':
+          description: successful operation
+definitions:
+  WikifierInput:
+    type: object
+    properties:
+      userKey:
+        type: string
+      text:
+        type: string
+      lang:
+        type: string
+      extraVocabularies:
+        type: string
+        default: 'angellist,australia,canada,jobsadzuna,panamapapers,slovenia,uk,usa'
+        pattern: '^(angellist|australia|canada|jobsadzuna|panamapapers|slovenia|uk|usa)(,(angellist|australia|canada|jobsadzuna|panamapapers|slovenia|uk|usa))*$'
+      wikiDataClasses:
+        type: string
+      wikiDataClassIds:
+        type: string
+      support:
+        type: string
+      ranges:
+        type: string
+      includeCosines:
+        type: string
+      maxMentionEntropy:
+        type: string
+      maxTargetsPerMention:
+        type: string
+      pageRankSqThreshold:
+        type: string
+      partsOfSpeech:
+        type: string
+      verbs:
+        type: string
+externalDocs:
+  description: More Wikifier details
+  url: 'http://wikifier.org/info.html'


### PR DESCRIPTION
Add OpenAPI 2.0 models for JSI's API services used by the
EuBusinessGraph Consortium partners. The following service APIs
are being described:

* Wikifier (with extraVocabularies functionality)
* EventRegistry Event Type Classification Service
* Graph Based Analytics Service